### PR TITLE
Added outputs for the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ script:
   - diff -u <(echo -n) <(gofmt -d -s .)
   - go tool vet .
   - go test -tags gtk_3_10 -covermode=count -coverprofile=profile.cov
-  - $HOME/gopath/bin/goveralls -v -coverprofile=profile.cov -service=travis-ci
+  - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
 after_success:
   - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/cmd/awsdefault/main.go
+++ b/cmd/awsdefault/main.go
@@ -46,10 +46,7 @@ func unsetDefaultProfile(file *awsdefault.CredentialsFile) *cli.Command {
 		Aliases: []string{"rm", "stop", "not"},
 		Usage:   "unset the AWS default profile.",
 		Action: func(c *cli.Context) error {
-			if err := file.UnSetDefault(); err != nil {
-				return err
-			}
-			return nil
+			return file.UnSetDefault()
 		},
 	}
 }
@@ -65,9 +62,58 @@ func setDefaultProfile(file *awsdefault.CredentialsFile) *cli.Command {
 					"the name of the profile used to become the new default is required",
 				)
 			}
-			if err := file.SetDefaultTo(c.Args().First()); err != nil {
+			return file.SetDefaultTo(c.Args().First())
+		},
+	}
+}
+
+func getUsedID(file *awsdefault.CredentialsFile) *cli.Command {
+	return &cli.Command{
+		Name:    "id",
+		Aliases: []string{"aws_access_key_id"},
+		Usage:   "Returns the AWS_ACCESS_KEY_ID of the currently used profile",
+		Action: func(c *cli.Context) error {
+			id, err := file.GetUsedID()
+			if err != nil {
 				return err
 			}
+			fmt.Println(id)
+			return nil
+		},
+	}
+}
+
+func getUsedKey(file *awsdefault.CredentialsFile) *cli.Command {
+	return &cli.Command{
+		Name:    "key",
+		Aliases: []string{"aws_secret_access_key"},
+		Usage:   "Returns the AWS_SECRET_ACCESS_KEY of the currently used profile",
+		Action: func(c *cli.Context) error {
+			k, err := file.GetUsedKey()
+			if err != nil {
+				return err
+			}
+			fmt.Println(k)
+			return nil
+		},
+	}
+}
+
+func printCredential(file *awsdefault.CredentialsFile) *cli.Command {
+	return &cli.Command{
+		Name:    "export",
+		Aliases: []string{"envs"},
+		Usage:   "Returns the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY of the currently used profile in form of export commands.",
+		Action: func(c *cli.Context) error {
+			id, err := file.GetUsedID()
+			if err != nil {
+				return err
+			}
+			k, err := file.GetUsedKey()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\nexport AWS_SECRET_ACCESS_KEY=%s\n", id, k)
 			return nil
 		},
 	}
@@ -85,6 +131,9 @@ func main() {
 		*setDefaultProfile(file),
 		*unsetDefaultProfile(file),
 		*getUsedProfile(file),
+		*getUsedID(file),
+		*getUsedKey(file),
+		*printCredential(file),
 		*getProfiles(file),
 	}
 	err = app.Run(os.Args)

--- a/cmd/awsdefault/readme.md
+++ b/cmd/awsdefault/readme.md
@@ -46,6 +46,61 @@ command:
 $ awsdefault rm
 ```
 
+## Show the AWS_ACCESS_KEY_ID of currently used profile
+
+command:
+
+```bash
+$ awsdefault id
+```
+
+- example output:
+
+```bash
+AAAAAAABBBBIIIIII
+```
+
+- tip: use it in parameters or bash scripts
+
+```bash
+AWS_ACCESS_KEY_ID=$(awsdefault id)
+```
+
+## Show the AWS_SECRET_ACCESS_KEY of currently used profile
+
+command:
+
+```bash
+$ awsdefault key
+```
+
+- example output:
+
+```bash
+aaaaeenntrnggg/trntruaelvii
+```
+
+## Print the export command for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY of currently used profile
+
+command:
+
+```bash
+$ awsdefault export
+```
+
+- example output:
+
+```bash
+export AWS_ACCESS_KEY_ID=AAAAAAABBBBIIIIII
+export AWS_SECRET_ACCESS_KEY=aaaaeenntrnggg/trntruaelvii
+```
+
+- tip: add an alias to your .bashrc or .zshrc like
+
+```bash
+alias awsexport='eval $(awsdefault export)'
+```
+
 # Installation
 
 ## Option 1 — Download binaries


### PR DESCRIPTION
The new subcommand 'id' prints the AWS_ACCESS_KEY_ID of the currently
used profile. The also added command 'key' prints the regarding
AWS_SECRET_ACCESS_KEY. For an easier export of these ID and KEY, the
command 'export' returns the export commands. This command can be used
for example together with the eval command to create an oneliner
exporting the credentials to the current shell.